### PR TITLE
Introduce new addon storybook-react-context

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,6 @@
 module.exports = {
   extends: ['@storybook/eslint-config-storybook'],
-  rules: {
-    'import/no-extraneous-dependencies': [
-      'error',
-      { devDependencies: ['test/**/*.js', '**/*.test.js'] },
-    ],
-  },
+  rules: {},
   overrides: [
     {
       files: ['**/*.ts', '**/*.tsx', '**/*.stories.js'],
@@ -14,10 +9,11 @@ module.exports = {
       },
     },
     {
-      files: ['test/**/*.js'],
+      files: ['test/**/*.js', '**/*.test.js'],
       rules: {
         'jest/expect-expect': 'off',
         'jest/no-test-callback': 'off',
+        'import/no-extraneous-dependencies': 'off',
       },
     },
   ],

--- a/README.md
+++ b/README.md
@@ -11,4 +11,7 @@
 ## Add-ons
 
 - [**storybook-fixtures**](./packages/storybook-fixtures)  
-  Map local and remote data fixtures to knob selectors (radio/select), making it easier to create variations for components. 
+  Add data fixtures to your components by using local data (JSON files or hardcoded) or even URLs to fetch the data from. 
+
+- [**storybook-react-context**](./packages/storybook-react-context)  
+  Manipulate React context inside Storybook. Read state and dispatch updates from outside of React component. 

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -10,6 +10,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "storybook-fixtures": "^0.8.5",
+    "storybook-react-context": "^0.1.0",
     "tailwindcss": "^1.9.6"
   },
   "devDependencies": {

--- a/examples/react/storybook-react-context.stories.js
+++ b/examples/react/storybook-react-context.stories.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { withReactContext } from 'storybook-react-context';
+
+const Component = ({ children, color, loading, onClick }) => (
+  <div className="font-sans max-w-sm rounded overflow-hidden shadow-lg bg-white p-4">
+    {children}
+    <hr />
+    {loading && (
+      <p id="context-loading" className="text-gray-600 my-6">
+        Loading…
+      </p>
+    )}
+    <p>
+      Color:{' '}
+      <span id="context-color" className={`p-2 bg-${color}`}>
+        {color}
+      </span>
+    </p>
+    {onClick && (
+      <p className="mt-6">
+        <button
+          type="button"
+          id="context-button"
+          className="py-2 px-4 text-base rounded border-none bg-gray-300 hover:bg-gray-400"
+          onClick={onClick}
+        >
+          Toggle colour
+        </button>
+      </p>
+    )}
+  </div>
+);
+
+const getNextColor = (currentColor) => {
+  const colors = [
+    'teal-400',
+    'green-400',
+    'blue-400',
+    'yellow-600',
+    'purple-400',
+    'pink-400',
+  ];
+  const currentIndex = colors.findIndex((c) => c === currentColor);
+  const nextIndex = currentIndex + 1 === colors.length ? 0 : currentIndex + 1;
+  return colors[nextIndex];
+};
+
+export default {
+  title: 'storybook-react-context',
+  decorators: [withReactContext],
+};
+
+export const changeContextOnMount = (_, { context: { state, dispatch } }) => {
+  React.useEffect(() => {
+    setTimeout(() => {
+      dispatch({
+        loaded: true,
+        color: 'red-400',
+      });
+    }, 2000);
+  }, []);
+
+  return (
+    <Component title="Context changes" color={state.color} loading={!state.loaded}>
+      <h2>Context change on mount</h2>
+      <p>
+        Context is initialised with values, then updated after 2 seconds to emulate
+        loading.
+      </p>
+    </Component>
+  );
+};
+changeContextOnMount.parameters = {
+  initialState: {
+    loaded: false,
+    color: 'blue-400',
+  },
+};
+
+export const changeContextOnClick = (_, { context: { state, dispatch } }) => {
+  function handleButtonToggle() {
+    dispatch({
+      color: getNextColor(state.color),
+    });
+  }
+
+  return (
+    <Component
+      title="Context changes"
+      color={state.color}
+      loading={!state.loaded}
+      onClick={handleButtonToggle}
+    >
+      <h2>Context change on click</h2>
+      <p>Context is updated on button click.</p>
+    </Component>
+  );
+};
+changeContextOnClick.parameters = {
+  initialState: {
+    loaded: true,
+    color: 'blue-400',
+  },
+};

--- a/packages/storybook-react-context/README.md
+++ b/packages/storybook-react-context/README.md
@@ -1,0 +1,58 @@
+# storybook-react-context
+
+Manipulate React context inside Storybook. Read state and dispatch updates from outside of React component.
+
+[![React examples](https://img.shields.io/badge/react-blueviolet?style=for-the-badge&logo=storybook&label=examples)](https://tyom.github.io/storybook-addons/react)
+
+## Install
+
+```
+npm install -D storybook-react-context
+```
+
+## Usage
+
+Add `withReactContext` decorator where needed, per component or globally.
+
+```js
+import { withReactContext } from 'storybook-react-context';
+
+export default {
+  title: 'some story',
+  decorators: [withReactContext],
+};
+```
+
+### Options
+
+`withReactContext` takes an argument which is an object with two keys (both optional):
+
+- `context` - custom context returned by `React.createContext`
+- `reducer` - custom reducer (defaults to a simple assignment of dispatch action on the current state)
+
+Initial context state can be set in parameters using `initialState` key:
+
+```js
+someComponent.parameters = {
+  initialState: {
+    defaultValue: true,
+  },
+};
+```
+
+Component will be wrapped with another component which uses the context hook and returns
+it to the story via story context.
+
+```js
+import { withReactContext } from 'storybook-react-context';
+
+export const myStory = (_, { context: { state, dispatch } }) => (
+  <button onClick={() => dispatch({ text: 'Changed' })}>{state.text}</button>
+);
+myStory.decorators = [withReactContext];
+myStory.parameters.initialState = {
+  initialState: {
+    text: 'Initial',
+  },
+};
+```

--- a/packages/storybook-react-context/package.json
+++ b/packages/storybook-react-context/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "storybook-react-context",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "scripts": {
+    "build": "del dist && tsc",
+    "watch": "del dist && tsc --watch"
+  },
+  "dependencies": {
+    "react": "^17.0.1",
+    "@storybook/addons": "^6.0.26"
+  },
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts"
+  ],
+  "keywords": [
+    "react",
+    "react-storybook",
+    "addon",
+    "context"
+  ],
+  "homepage": "https://github.com/tyom/storybook-addons/tree/master/packages/storybook-react-context",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tyom/storybook-addons.git",
+    "directory": "packages/storybook-react-context"
+  },
+  "bugs": {
+    "url": "https://github.com/tyom/storybook-addons/issues"
+  },
+  "author": {
+    "name": "Tyom Semonov",
+    "email": "mail@tyom.net"
+  },
+  "license": "MIT"
+}

--- a/packages/storybook-react-context/src/decorator.tsx
+++ b/packages/storybook-react-context/src/decorator.tsx
@@ -1,0 +1,53 @@
+/* global window */
+import React from 'react';
+import { makeDecorator, StoryContext } from '@storybook/addons';
+import { ADDON_ID, PARAM_KEY } from '.';
+
+const DefaultContext = React.createContext({
+  default: true,
+});
+
+function defaultReducer(state, action) {
+  return {
+    ...state,
+    ...action,
+  };
+}
+
+const ContextWrapper = ({ context, children }) => {
+  if (typeof children !== 'function') {
+    throw new Error('ContextWrapper children must be a function');
+  }
+  return children(React.useContext(context));
+};
+
+export const withReactContext = makeDecorator({
+  name: ADDON_ID,
+  parameterName: PARAM_KEY,
+  wrapper: (
+    storyFn: (context: StoryContext) => any,
+    context,
+    { options, parameters = {} }
+  ) => {
+    if (options?.reducer && typeof options.reducer !== 'function') {
+      throw new Error('Custom reducer argument must be a function');
+    }
+    const ReactContext = options?.context || DefaultContext;
+    const reducer = options?.reducer || defaultReducer;
+
+    const [state, dispatch] = React.useReducer(reducer, parameters);
+
+    return (
+      <ReactContext.Provider value={{ state, dispatch }}>
+        <ContextWrapper context={ReactContext}>
+          {(ctx) =>
+            storyFn({
+              ...context,
+              context: ctx,
+            })
+          }
+        </ContextWrapper>
+      </ReactContext.Provider>
+    );
+  },
+});

--- a/packages/storybook-react-context/src/index.ts
+++ b/packages/storybook-react-context/src/index.ts
@@ -1,0 +1,4 @@
+export const ADDON_ID = 'storybook-react-context';
+export const PARAM_KEY = 'initialState';
+
+export { withReactContext } from './decorator';

--- a/packages/storybook-react-context/tsconfig.json
+++ b/packages/storybook-react-context/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/test/functional/page-model.js
+++ b/test/functional/page-model.js
@@ -11,11 +11,11 @@ class Page {
     );
   }
 
-  assertTextInPreview(selector, expectedText) {
+  assertTextInPreview(selector, expectedText, assertionOptions) {
     return t
       .switchToIframe('#storybook-preview-iframe')
       .expect(Selector(selector).innerText)
-      .eql(expectedText)
+      .eql(expectedText, assertionOptions)
       .switchToMainWindow();
   }
 
@@ -24,6 +24,13 @@ class Page {
       .switchToIframe('#storybook-preview-iframe')
       .expect(Selector(selector).hasClass(className))
       .eql(true)
+      .switchToMainWindow();
+  }
+
+  clickInPreview(selector) {
+    return t
+      .switchToIframe('#storybook-preview-iframe')
+      .click(selector)
       .switchToMainWindow();
   }
 

--- a/test/functional/storybook-fixtures.test.js
+++ b/test/functional/storybook-fixtures.test.js
@@ -45,7 +45,7 @@ environmentUseCases.forEach(({ urlPath, fixtureName }) => {
     .meta(
       'target',
       fixtureName.toLowerCase()
-    )(fixtureName)
+    )(`storybook-fixtures ${fixtureName}`)
     .page(BASE_URL + urlPath);
 
   test('Fixture Sections', async (t) => {

--- a/test/functional/storybook-react-context.test.js
+++ b/test/functional/storybook-react-context.test.js
@@ -1,0 +1,37 @@
+import page from './page-model';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5000';
+
+const getUrlPath = (path = '') =>
+  BASE_URL + (BASE_URL.includes(':6006') ? '' : '/react') + path;
+
+fixture('React').meta({ target: 'react' }).page(getUrlPath());
+
+test('React context is set on mount', async (t) => {
+  await page.selectSidebarItem('storybook-react-context');
+  await page.selectSidebarItem('Change Context On Mount');
+  // decrease timeout. Setting on mount is emulated with 2s timeout in component
+  await page.assertTextInPreview('#context-loading', 'Loading…', {
+    timeout: 1500,
+  });
+  await page.assertTextInPreview('#context-color', 'blue-400', {
+    timeout: 1500,
+  });
+  await t.wait(2000);
+  await page.assertTextInPreview('#context-color', 'red-400');
+});
+
+test('React context is set on button click', async (t) => {
+  await page.selectSidebarItem('storybook-react-context');
+  await page.selectSidebarItem('Change Context On Click');
+
+  await page.assertTextInPreview('#context-color', 'blue-400');
+
+  await page.clickInPreview('#context-button');
+
+  await page.assertTextInPreview('#context-color', 'yellow-600');
+
+  await page.clickInPreview('#context-button');
+
+  await page.assertTextInPreview('#context-color', 'purple-400');
+});

--- a/test/functional/storybook-react-context.test.js
+++ b/test/functional/storybook-react-context.test.js
@@ -5,7 +5,7 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:5000';
 const getUrlPath = (path = '') =>
   BASE_URL + (BASE_URL.includes(':6006') ? '' : '/react') + path;
 
-fixture('React').meta({ target: 'react' }).page(getUrlPath());
+fixture('storybook-react-context').meta({ target: 'react' }).page(getUrlPath());
 
 test('React context is set on mount', async (t) => {
   await page.selectSidebarItem('storybook-react-context');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,7 +2759,7 @@
     react-syntax-highlighter "^12.2.1"
     regenerator-runtime "^0.13.3"
 
-"@storybook/addons@6.0.28", "@storybook/addons@^6.0.28":
+"@storybook/addons@6.0.28", "@storybook/addons@^6.0.26", "@storybook/addons@^6.0.28":
   version "6.0.28"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.0.28.tgz#8c7ef3229706e2dc32d40ec9158431a3ffee3e5b"
   integrity sha512-3Brf9w/u2sw0huarcO1iLFBmGt7KtApRxX4bFcsRiPPFxliDrmb1sAsd37UbKp8qBSw1U6FByjuTJQ7xn/TDhg==
@@ -14229,7 +14229,7 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@17.0.1:
+react@17.0.1, react@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==


### PR DESCRIPTION
This addon gives access to context inside React component in Storybook story to the story closure. It's added to the context story amd can be accessed in the second argument of the story definition.

```js
export const myStory = (_, { context: { state, dispatch } }) => {
  // story body
}
myStory.decorators = [withReactContext];
```

`withReactContext` can provide a custom reducer and context. By default state is assumed to be an object that is shallow assigned with new value set in dispatch.

```js
withReactContext({
  context: React.createContext('')
  reducer: (state = '', action) ⇒ state + action;
})
```