### PR TITLE
Refactor storybook-react-context

### DIFF
--- a/packages/storybook-react-context/README.md
+++ b/packages/storybook-react-context/README.md
@@ -23,47 +23,59 @@ export default {
 };
 ```
 
+The decorator can also be preconfigured for all stories in the module:
+
+```js
+export default {
+  title: 'some story',
+  decorators: [
+    withReactContext({
+      Context: ExampleContext,
+      initialState: { authenticated: false },
+    }),
+  ],
+};
+```
+
 ### Options
 
 `withReactContext` takes an argument which is an object with the following optional properties:
 
-- `context` - custom context returned by `React.createContext`
-- `reducer` - custom reducer (defaults to a simple assignment of dispatch action on the current state)
-- `useReducer` - when set to `false` avoids using `useReducer` hook in provider value, instead pass the `initialState` directly
-- `initialState` - initial state to use in useReducer for context provider value
+- `Context` - The context returned by `React.createContext` to provide for story's components
+- `reducer(state, action)` - custom reducer to produce the provider value or;
+- `useProviderValue(state, args)` - a function (hook) to be used to derive the provider value (provides story args as second argument to link with Storybook Controls)
+- `initialState` - the initial state to use for the provider value
 
-Initial context state can also be set in parameters using `initialState` key:
+The decorator options can also be se set in story parameters using `reactContext` key:
 
 ```js
 someComponent.parameters = {
-  initialState: {
-    defaultValue: true,
-  },
+  reactContext: {
+    initialState: {
+      defaultValue: true,
+    },
+    reducer: (state, action) => ({ ...state, action })
+  }
 };
 ```
-
-When both `initialState` values (in decorator argument and parameters) are objects
-they are combined (assigned), otherwise the either `initialState` in parameters or
-decorator argument will be used (in that order).
 
 Component will be wrapped with another component which uses the context hook and returns
 it to the story via story context as the result of `React.useReducer` with `reducer`
 function and `initialState`.
 
+The `useProviderValue` hook can be used to link the context with Storybook Controls.
+
 ```js
 import { withReactContext } from 'storybook-react-context';
 
-export const myStory = (_, { context: [state, dispatch] }) => (
+export const myStory = ({ myValue }) => (
   <button onClick={() => dispatch({ text: 'Changed' })}>{state.text}</button>
 );
-myStory.decorators = [withReactContext({
-  initialState: {
-    title: 'Initial #1'
-  }
-})];
-myStory.parameters.initialState = {
-  initialState: {
-    text: 'Initial #2',
-  },
+myStory.args = {
+  myValue: true,
+}
+myStory.decorators = [withReactContext];
+myStory.parameters.reactContextState = {
+  useProviderValue: (state, args) => args
 };
 ```

--- a/packages/storybook-react-context/src/index.ts
+++ b/packages/storybook-react-context/src/index.ts
@@ -1,4 +1,4 @@
 export const ADDON_ID = 'storybook-react-context';
-export const PARAM_KEY = 'initialState';
+export const PARAM_KEY = 'reactContext';
 
 export { withReactContext } from './decorator';

--- a/test/functional/storybook-react-context.test.js
+++ b/test/functional/storybook-react-context.test.js
@@ -7,51 +7,60 @@ const getUrlPath = (path = '') =>
 
 fixture('storybook-react-context').meta({ target: 'react' }).page(getUrlPath());
 
-test('React context is set on mount', async (t) => {
+test('React context is set from useEffect', async (t) => {
   await t.click('#storybook-react-context');
 
-  await page.selectSidebarItem('Change Context On Mount');
+  await page.selectSidebarItem('Simulate Loading');
   // decrease timeout. Setting on mount is emulated with 2s timeout in component
-  await page.assertTextInPreview('#context-loading', 'Loading…', {
+  await page.assertTextInPreview('#loading-status', 'Loading…', {
     timeout: 1500,
   });
-  await page.assertTextInPreview('#context-color', 'blue-400', {
+  await page.assertTextInPreview('#auth-status', 'Unauthenticated', {
     timeout: 1500,
   });
   await t.wait(2000);
-  await page.assertTextInPreview('#context-color', 'red-400');
+  await page.assertTextInPreview('#loading-status', 'Loaded.');
+  await page.assertTextInPreview('#auth-status', 'Authenticated', {
+    timeout: 1500,
+  });
 });
 
 test('React context is set on button click', async (t) => {
   await t.click('#storybook-react-context');
 
-  await page.selectSidebarItem('Change Context On Click');
+  await page.selectSidebarItem('Change On Interaction');
 
-  await page.assertTextInPreview('#context-color', 'blue-400');
-
-  await page.clickInPreview('#context-button');
-
-  await page.assertTextInPreview('#context-color', 'yellow-600');
+  await page.assertTextInPreview('#auth-status', 'Unauthenticated');
 
   await page.clickInPreview('#context-button');
 
-  await page.assertTextInPreview('#context-color', 'purple-400');
+  await page.assertTextInPreview('#auth-status', 'Authenticated');
+
+  await page.clickInPreview('#context-button');
+
+  await page.assertTextInPreview('#auth-status', 'Unauthenticated');
 });
 
-test('Use React context without reducer', async (t) => {
+test('React context is set statically in story parameters', async (t) => {
   await t.click('#storybook-react-context');
 
-  await page.selectSidebarItem('No Reducer');
+  await page.selectSidebarItem('Static Initial Context');
 
-  await page.assertTextInPreview('#context-color', 'red-400');
+  await page.assertTextInPreview('#auth-status', 'Authenticated');
+});
+
+test('React context is updated with Storybook Controls', async (t) => {
+  await t.click('#storybook-react-context');
+
+  await page.selectSidebarItem('Update Context From Args');
+
+  await page.assertTextInPreview('#auth-status', 'Unauthenticated');
 
   await page.selectPanel('Controls');
+  await t.click(page.controlsPanel.find('label[for=authenticated]'));
 
-  await page.selectControl('blue');
+  await page.assertTextInPreview('#auth-status', 'Authenticated');
 
-  await page.assertTextInPreview('#context-color', 'blue-400');
-
-  await page.selectControl('green');
-
-  await page.assertTextInPreview('#context-color', 'green-400');
+  await t.click(page.controlsPanel.find('label[for=authenticated]'));
+  await page.assertTextInPreview('#auth-status', 'Unauthenticated');
 });

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,5 +1,0 @@
-module.exports = () => ({
-  autoDetect: true,
-  files: [{ pattern: 'packages/**/src/**/*.ts?(x)' }],
-  tests: ['packages/**/*.test.js', 'packages/**/*.test.ts'],
-});


### PR DESCRIPTION
BREAKING CHANGE

Reviewed the stories with use cases and changed `context` parameter to `Context` to avoid confusion with story context.

See the examples stories for usage.

Issue #25.